### PR TITLE
Fix controller cache sync functions

### DIFF
--- a/controller.go
+++ b/controller.go
@@ -38,6 +38,7 @@ type Controller struct {
 	handler cache.ResourceEventHandler
 }
 
+// Deprecated: moved into solo-kit
 // NewController returns a new controller
 func NewController(
 	controllerName string,

--- a/controller.go
+++ b/controller.go
@@ -49,16 +49,15 @@ func NewController(
 	eventBroadcaster.StartLogging(log.Printf)
 	eventBroadcaster.StartRecordingToSink(&typedcorev1.EventSinkImpl{Interface: kubeclient.CoreV1().Events("")})
 	recorder := eventBroadcaster.NewRecorder(scheme.Scheme, corev1.EventSource{Component: controllerName})
-	var hasSyncedFuncs []cache.InformerSynced
 
 	c := &Controller{
-		syncFuncs: hasSyncedFuncs,
 		name:      controllerName,
 		workqueue: workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), controllerName),
 		recorder:  recorder,
 		handler:   handler,
 	}
 
+	var hasSyncedFuncs []cache.InformerSynced
 	for _, informer := range informers {
 		hasSyncedFuncs = append(hasSyncedFuncs, informer.HasSynced)
 
@@ -75,6 +74,7 @@ func NewController(
 			},
 		})
 	}
+	c.syncFuncs = hasSyncedFuncs
 
 	return c
 }

--- a/handlers.go
+++ b/handlers.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 )
 
+// Deprecated: moved into solo-kit
 // returns a handler that runs f() every time an update occurs,
 // regardless of which type of update
 func NewSyncHandler(f func()) cache.ResourceEventHandler {
@@ -21,6 +22,7 @@ func NewSyncHandler(f func()) cache.ResourceEventHandler {
 	}
 }
 
+// Deprecated: moved into solo-kit
 // returns a handler that runs f() every time an update occurs,
 // regardless of which type of update
 // ensures only one f() can run at a time


### PR DESCRIPTION
Fixed a bug that caused the controller to always be initialized with an empty collection of syncer functions.

DO NOT MERGE: we might need to pin the version in projects that include this as a dependency before applying the change